### PR TITLE
fix(vt): switching the header file import method according to the linking method

### DIFF
--- a/packages/visual-tracking/ios/RNKRTVisualTracking/RNKRTVisualTrackingModule.m
+++ b/packages/visual-tracking/ios/RNKRTVisualTracking/RNKRTVisualTrackingModule.m
@@ -15,7 +15,12 @@
 //
 
 #import "RNKRTVisualTrackingModule.h"
+
+#if __has_include("RNKRTVisualTracking-Swift.h")
+#import "RNKRTVisualTracking-Swift.h"
+#else
 #import <RNKRTVisualTracking/RNKRTVisualTracking-Swift.h>
+#endif
 
 @implementation RNKRTVisualTrackingModule
 


### PR DESCRIPTION
Since the import method of header files differs between dynamic and static links, the import method should be switched according to the link method.