### PR TITLE
Update `RemoteMessage` Type in `Notification.create`

### DIFF
--- a/packages/notification/src/types.tsx
+++ b/packages/notification/src/types.tsx
@@ -24,5 +24,5 @@ export interface KRTNotificationNativeModule {
 }
 
 export interface RemoteMessage {
-  data?: { [key: string]: string };
+  data?: { [key: string]: string | object };
 }


### PR DESCRIPTION
**Description**:

Thank you for developing the karte SDK for react-native.

## Overview
This PR proposes a modification to the type of `RemoteMessage` that `Notification.create` accepts.

### Details
We're utilizing version v18.3.0 of `@react-native-firebase/messaging`. A recent PR in `@react-native-firebase/messaging`, [view it here](https://github.com/invertase/react-native-firebase/pull/7316), introduced changes to the `RemoteMessage` type. This PR aims to address and adjust to those changes:

```diff
- data?: { [key: string]: string };
+ data?: { [key: string]: string | object };
```

## Additional Notes
- Confirmed that `yarn tsc --noEmit` runs without issues.
- Ensured that `yarn test` executes successfully.
- Verified that `yarn build` operates correctly.

- My knowledge in Swift and Kotlin is limited; hence, I haven't been able to verify if these type changes have any side effects in the nativeModule.