### PR TITLE
feat(variables): add clearCacheAll method

### DIFF
--- a/packages/variables/android/src/main/java/io/karte/react/variables/KarteVariablesModule.kt
+++ b/packages/variables/android/src/main/java/io/karte/react/variables/KarteVariablesModule.kt
@@ -122,4 +122,10 @@ class KarteVariablesModule(reactContext: ReactApplicationContext) : ReactContext
       keys.forEach { pushString(it) }
     }
   }
+
+  @ReactMethod
+  fun clearCacheAll() {
+    Variables.clearCacheAll()
+    variables.clear()
+  }
 }

--- a/packages/variables/ios/RNKRTVariables/RNKRTVariablesModule.m
+++ b/packages/variables/ios/RNKRTVariables/RNKRTVariablesModule.m
@@ -144,4 +144,9 @@ RCT_REMAP_BLOCKING_SYNCHRONOUS_METHOD(getAllKeys, NSArray *, getAllKeys) {
     return [KRTVariables getAllKeys];
 }
 
+RCT_REMAP_METHOD(clearCacheAll, clearCacheAll) {
+    [KRTVariables clearCacheAll];
+    [self.variables removeAllObjects];
+}
+
 @end

--- a/packages/variables/src/index.tsx
+++ b/packages/variables/src/index.tsx
@@ -83,6 +83,13 @@ export class Variables {
   public static getAllKeys(): Array<string> {
     return nativeModule.getAllKeys();
   }
+
+  /**
+   * 全ての設定値のキャッシュを削除します。
+   */
+  public static clearCacheAll(): void {
+    nativeModule.clearCacheAll();
+  }
 }
 
 /**

--- a/packages/variables/src/types.tsx
+++ b/packages/variables/src/types.tsx
@@ -27,4 +27,5 @@ export interface KRTVariablesNativeModule {
   getObject(key: string, defaultValue: object): object;
   clearCacheByKey(key: string): void;
   getAllKeys(): Array<string>;
+  clearCacheAll(): void;
 }


### PR DESCRIPTION
## Summary
- Add `clearCacheAll()` method to Variables class for clearing all variable caches
- Implement native bridge methods for both Android and iOS platforms  
- Add TypeScript definitions and documentation

## Implementation Details
### Android
- Added `clearCacheAll()` method in `KarteVariablesModule.kt`
- Calls `Variables.clearCacheAll()` from Android SDK
- Clears internal `variables` Map to maintain consistency

### iOS  
- Added `clearCacheAll()` method in `RNKRTVariablesModule.m`
- Calls `[KRTVariables clearCacheAll]` from iOS SDK
- Clears internal `variables` dictionary to maintain consistency

### React Native
- Added method definition to `KRTVariablesNativeModule` interface
- Added public static method `clearCacheAll()` to `Variables` class
- Added JSDoc documentation in Japanese following existing patterns

## Test Plan
- [ ] Test on Android device/emulator
- [ ] Test on iOS device/simulator  
- [ ] Verify cache is properly cleared after calling method
- [ ] Verify internal variable state is reset

🤖 Generated with [Claude Code](https://claude.ai/code)